### PR TITLE
Endpoints for sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,29 @@ search service specification.
 
 # Getting Started
 
-To get started, clone this repository.
+Install Headjack Search Service.
+```sh
+pip install headjack-search-service
+```
+
+Start the service.
+```sh
+headjack-search-service --host 0.0.0.0 --port 16410
+```
+
+You can configure the service with the following environment variables.
+
+| Environment Variable         | Description                                     | Example            |
+|------------------------------|-------------------------------------------------|--------------------|
+| HSS_CHROMA_API_IMPL          | Chroma API implementation (rest or local)       | rest               |
+| HSS_CHROMA_DB_IMPL           | Chroma DB implementation                        | duckdb+parquet     |
+| HSS_CHROMA_HOST              | Chroma DB Host                                  | 0.0.0.0            |
+| HSS_CHROMA_PORT              | Chroma DB Port                                  | 16411              |
+| HSS_CHROMA_PERSIST_DIRECTORY | The directory to persist data (local mode only) | /chroma/data/index |
+
+# Docker Compose Demo
+
+To use the docker compose demo, clone this repository.
 
 ```sh
 git clone https://github.com/KnowledgeForge/headjack-search-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,9 @@ services:
     networks:
       - headjack-network
     environment:
-      - DOTENV_FILE=.env
+      - HSS_CHROMA_API_IMPL=rest
+      - HSS_CHROMA_HOST=hss-chromadb
+      - HSS_CHROMA_PORT=16411
     volumes:
       - .:/code
     command: uvicorn headjack_search_service.api.app:app --host 0.0.0.0 --port 16410 --reload

--- a/examples/embed.py
+++ b/examples/embed.py
@@ -152,7 +152,7 @@ if __name__ == "__main__":
         client.get_collection(name="metrics")
         _logger.info("Skipped embedding metrics data, collection already exists.")
         skipped_metrics = True
-    except ValueError:
+    except Exception:
         index_metrics(dj_url=args.dj, client=client)
         _logger.info("Metrics indexing completed")
 
@@ -160,7 +160,7 @@ if __name__ == "__main__":
         client.get_collection(name="knowledge")
         _logger.info("Skipped embedding knowledge data, collection already exists.")
         skipped_knowledge = True
-    except ValueError:
+    except Exception:
         index_knowledge(knowledge_dir=args.knowledge, client=client)
         _logger.info("Knowledge indexing completed")
 

--- a/examples/embed.py
+++ b/examples/embed.py
@@ -2,11 +2,11 @@
 Script to load knowledge documents into a vector database
 """
 import argparse
-import re
-from glob import glob
 import logging
-from pathlib import Path
+import re
 import sys
+from glob import glob
+from pathlib import Path
 
 import chromadb
 import requests
@@ -15,27 +15,26 @@ from chromadb.config import Settings
 from chromadb.utils import embedding_functions
 
 logging.basicConfig(
-    format='%(asctime)s - %(levelname)s - %(funcName)s - %(message)s  ',
-    datefmt='%d-%b-%y %H:%M:%S',
-    level=logging.INFO
+    format="%(asctime)s - %(levelname)s - %(funcName)s - %(message)s  ", datefmt="%d-%b-%y %H:%M:%S", level=logging.INFO
 )
 _logger = logging.getLogger("embed.py")
+
 
 def get_chroma_client(host: str, port: str) -> chromadb.Client:
     """
     Get a chroma client
     """
     _logger.info(f"Getting chroma client for host {host} and port {port}")
-    return chromadb.Client(Settings(
+    return chromadb.Client(
+        Settings(
             chroma_api_impl="rest",
             chroma_server_host=host,
             chroma_server_http_port=port,
-        ),)
+        ),
+    )
 
 
-def window_document(
-    file_name: str, document_text: str, window_size: int = 200, overlap: int = 50
-):
+def window_document(file_name: str, document_text: str, window_size: int = 200, overlap: int = 50):
     """
     Splits a document into overlapping windows of fixed size.
 
@@ -48,10 +47,7 @@ def window_document(
         List[str]: A list of overlapping windows.
     """
     document = re.split(r"\s+", document_text)
-    title = (
-        re.split(r"[._-]+", file_name)
-        + re.split(r"\s+", document_text.split("\n")[0])[:10]
-    )
+    title = re.split(r"[._-]+", file_name) + re.split(r"\s+", document_text.split("\n")[0])[:10]
     windows = []
     start = 0
     end = window_size
@@ -71,9 +67,7 @@ def index_metrics(dj_url: str, client: chromadb.Client):
     _logger.info(f"Indexing DataJunction metrics ({dj_url})")
     metrics_collection = client.get_or_create_collection(
         "metrics",
-        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(
-            model_name="all-MiniLM-L6-v2"
-        ),
+        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2"),
     )
 
     # Get DJ metrics
@@ -111,9 +105,7 @@ def index_knowledge(knowledge_dir: str, client: chromadb.Client):
     _logger.info(f"Indexing knowledge documents ({knowledge_dir})")
     knowledge_collection = client.get_or_create_collection(
         "knowledge",
-        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(
-            model_name="all-MiniLM-L6-v2"
-        ),
+        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2"),
     )
     knowledge_files = glob(knowledge_dir)
     knowledge_doc_texts = {}
@@ -160,7 +152,7 @@ if __name__ == "__main__":
         client.get_collection(name="metrics")
         _logger.info("Skipped embedding metrics data, collection already exists.")
         skipped_metrics = True
-    except Exception:
+    except ValueError:
         index_metrics(dj_url=args.dj, client=client)
         _logger.info("Metrics indexing completed")
 
@@ -168,7 +160,7 @@ if __name__ == "__main__":
         client.get_collection(name="knowledge")
         _logger.info("Skipped embedding knowledge data, collection already exists.")
         skipped_knowledge = True
-    except Exception:
+    except ValueError:
         index_knowledge(knowledge_dir=args.knowledge, client=client)
         _logger.info("Knowledge indexing completed")
 

--- a/headjack_search_service/api/app.py
+++ b/headjack_search_service/api/app.py
@@ -10,11 +10,10 @@ from uuid import uuid4
 import uvicorn
 
 from chromadb.api import API
-from chromadb.utils import embedding_functions
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 
-from headjack_search_service.api.helpers import get_chroma_client
+from headjack_search_service.api.helpers import get_chroma_client, get_embedding_function
 from headjack_search_service.api.models import Utterance, UtteranceType
 
 _logger = logging.getLogger(__name__)
@@ -54,7 +53,7 @@ async def save_utterances_for_a_session(
     _logger.info(f"Saving utterances for session {session_id}")
     chroma_collection = chroma_client.get_or_create_collection(
         "session_history",
-        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2"),
+        embedding_function=get_embedding_function(),
     )
 
     documents = []
@@ -86,7 +85,7 @@ async def search_utterances_for_a_session(
     _logger.info(f"Pulling utterances for session {session_id}")
     chroma_collection = chroma_client.get_or_create_collection(
         "session_history",
-        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2"),
+        embedding_function=get_embedding_function(),
     )
     num_elements = chroma_collection.count()
     try:

--- a/headjack_search_service/api/app.py
+++ b/headjack_search_service/api/app.py
@@ -1,15 +1,18 @@
 """
 Headjack search service
 """
+import argparse
 import asyncio
 import logging
 from enum import Enum
 from typing import List, Optional
 from uuid import uuid4
+import uvicorn
 
-from chromadb.api.local import LocalAPI
+from chromadb.api import API
 from chromadb.utils import embedding_functions
 from fastapi import Depends, FastAPI, HTTPException
+from fastapi.responses import JSONResponse
 
 from headjack_search_service.api.helpers import get_chroma_client
 from headjack_search_service.api.models import Utterance, UtteranceType
@@ -27,7 +30,7 @@ app = FastAPI()
 
 @app.get("/healthcheck")
 @app.get("/healthcheck/", include_in_schema=False)
-async def health_check(*, chroma_client: LocalAPI = Depends(get_chroma_client)):
+async def health_check(*, chroma_client: API = Depends(get_chroma_client)):
     _logger.info(f"Pinging chroma database...")
     chroma_client.heartbeat()
     _logger.info(f"Pinging successful")
@@ -36,20 +39,17 @@ async def health_check(*, chroma_client: LocalAPI = Depends(get_chroma_client)):
 
 @app.get("/query")
 @app.get("/query/", include_in_schema=False)
-async def query(text: str, collection: COLLECTION_TYPE, n: int = 3, *, chroma_client: LocalAPI = Depends(get_chroma_client)):
+async def query(text: str, collection: COLLECTION_TYPE, n: int = 3, *, chroma_client: API = Depends(get_chroma_client)):
     _logger.info(f"Connecting to collection for {collection.value}")
-    chroma_collection = chroma_client.get_collection(
-        collection.value,
-        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2"),
-    )
+    chroma_collection = chroma_client.get_collection(collection.value)
     results = chroma_collection.query(query_texts=[text], n_results=n)
     return results
 
 
 @app.post("/session/{session_id}")
 @app.post("/session/{session_id}/", include_in_schema=False)
-async def get_utterances_for_a_session(
-    session_id: str, *, utterances: List[Utterance], chroma_client: LocalAPI = Depends(get_chroma_client)
+async def save_utterances_for_a_session(
+    session_id: str, *, utterances: List[Utterance], chroma_client: API = Depends(get_chroma_client)
 ):
     _logger.info(f"Saving utterances for session {session_id}")
     chroma_collection = chroma_client.get_or_create_collection(
@@ -69,13 +69,19 @@ async def get_utterances_for_a_session(
         metadatas=metadatas,
         ids=ids,
     )
-    return 201
+    chroma_client.persist()
+    return JSONResponse(
+        status_code=201,
+        content={
+            "message": (f"Utterance successfully saved for session {session_id}"),
+        },
+    )
 
 
 @app.get("/session/{session_id}")
 @app.get("/session/{session_id}/", include_in_schema=False)
 async def search_utterances_for_a_session(
-    session_id: str, query: str, n: int = 3, type_: Optional[UtteranceType] = UtteranceType.user, *, chroma_client: LocalAPI = Depends(get_chroma_client)
+    session_id: str, query: str, n: int = 3, type_: Optional[UtteranceType] = UtteranceType.user, *, chroma_client: API = Depends(get_chroma_client)
 ):
     _logger.info(f"Pulling utterances for session {session_id}")
     chroma_collection = chroma_client.get_or_create_collection(
@@ -90,3 +96,10 @@ async def search_utterances_for_a_session(
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     return results
+
+def cli():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", help="Host")
+    parser.add_argument("--port", help="Port", type=int)
+    args = parser.parse_args()
+    uvicorn.run(app, host=args.host, port=args.port)

--- a/headjack_search_service/api/helpers.py
+++ b/headjack_search_service/api/helpers.py
@@ -4,11 +4,12 @@ Module containing all config related things
 import logging
 
 import chromadb
-from chromadb.config import Settings
 from chromadb.api.models.Collection import Collection
+from chromadb.config import Settings
 from chromadb.utils import embedding_functions
 
 _logger = logging.getLogger(__name__)
+
 
 def get_chroma_client():  # pragma: no cover
     """
@@ -23,6 +24,7 @@ def get_chroma_client():  # pragma: no cover
     )
     return chroma_client
 
+
 def get_collection(client: chromadb.Client, collection: str) -> Collection:
     """
     Get the headjack chroma collection
@@ -30,7 +32,5 @@ def get_collection(client: chromadb.Client, collection: str) -> Collection:
     _logger.info(f"Getting chroma collection {collection}")
     return client.get_or_create_collection(
         collection,
-        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(
-            model_name="all-MiniLM-L6-v2"
-        ),
+        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2"),
     )

--- a/headjack_search_service/api/helpers.py
+++ b/headjack_search_service/api/helpers.py
@@ -1,26 +1,37 @@
 """
 Module containing all config related things
 """
+from functools import lru_cache
 import logging
+from pydantic import BaseSettings
 
 import chromadb
 from chromadb.api.models.Collection import Collection
-from chromadb.config import Settings
+from chromadb.config import Settings as ChromaSettings
 from chromadb.utils import embedding_functions
 
 _logger = logging.getLogger(__name__)
 
+class Settings(BaseSettings):
+    hss_chroma_db_impl: str = "duckdb+parquet"
+    hss_chroma_api_impl: str = "local"
+    hss_chroma_host: str = "0.0.0.0"
+    hss_chroma_port: int = 16411
+    hss_chroma_persist_directory = "/Users/samredai/Workspaces/headjack-workspace/headjack-search-service/headjack-search-service-index"
 
 def get_chroma_client():  # pragma: no cover
     """
     Get a chromadb client
     """
+    settings = get_settings()
     chroma_client = chromadb.Client(
-        Settings(
-            chroma_api_impl="rest",
-            chroma_server_host="hss-chromadb",
-            chroma_server_http_port="16411",
-        ),
+        ChromaSettings(
+            chroma_db_impl=settings.hss_chroma_db_impl,
+            chroma_api_impl=settings.hss_chroma_api_impl,
+            chroma_server_host=settings.hss_chroma_host,
+            chroma_server_http_port=settings.hss_chroma_port,
+            persist_directory=settings.hss_chroma_persist_directory,
+        )
     )
     return chroma_client
 
@@ -30,7 +41,8 @@ def get_collection(client: chromadb.Client, collection: str) -> Collection:
     Get the headjack chroma collection
     """
     _logger.info(f"Getting chroma collection {collection}")
-    return client.get_or_create_collection(
-        collection,
-        embedding_function=embedding_functions.SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2"),
-    )
+    return client.get_or_create_collection(collection)
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/headjack_search_service/api/helpers.py
+++ b/headjack_search_service/api/helpers.py
@@ -43,6 +43,10 @@ def get_collection(client: chromadb.Client, collection: str) -> Collection:
     _logger.info(f"Getting chroma collection {collection}")
     return client.get_or_create_collection(collection)
 
-@lru_cache
+@lru_cache(maxsize=1)
+def get_embedding_function():
+    return embedding_functions.SentenceTransformerEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+
+@lru_cache(maxsize=1)
 def get_settings() -> Settings:
     return Settings()

--- a/headjack_search_service/api/models.py
+++ b/headjack_search_service/api/models.py
@@ -1,0 +1,22 @@
+"""
+Pydantic models
+"""
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class UtteranceType(str, Enum):
+    user = "user"
+    observation = "observation"
+    action = "action"
+    thought = "thought"
+    answer = "answer"
+
+
+class Utterance(BaseModel):
+    type: UtteranceType
+    timestamp: datetime
+    context: str = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 
+[project.scripts]
+headjack-search-service = "headjack_search_service.api.app:cli"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
This adds a `POST /session/{session}`  endpoint for embedding and saving context from utterances in a given session and also a `GET /session/{session}` endpoint for searching across utterances within a single session.

**Saving a user type utterance for a session `foo`**
```sh
curl -X 'POST' \
  'http://localhost:16410/session/abc' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '[
  {
    "type": "user",
    "timestamp": "2023-04-30T23:55:33.873Z",
    "context": "Where am I?"
  }
]'
```

**Semantic search of utterances in session `foo`**
```sh
curl -X 'GET' \
  'http://localhost:16410/session/abc?query=Where%20am%20I%20going%3F&type_=user&n=1' \
  -H 'accept: application/json'
```